### PR TITLE
fix: properly interact with Durable Objects via fetch API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "estado",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/src/durableState.ts
+++ b/src/durableState.ts
@@ -2,6 +2,38 @@ import type { LockInfo } from "./types/terraform";
 import { DurableObject } from "cloudflare:workers";
 
 export class DurableState extends DurableObject {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    
+    // Handle lock info request
+    if (request.method === "GET" && url.pathname === "/lock") {
+      const lockInfo = await this.getLockInfo();
+      return new Response(JSON.stringify(lockInfo), {
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+    
+    // Handle lock request
+    if (request.method === "POST" && url.pathname === "/lock") {
+      const info = await request.json() as LockInfo;
+      const result = await this.lock(info);
+      return new Response(null, { 
+        status: result ? 200 : 423 
+      });
+    }
+    
+    // Handle unlock request
+    if (request.method === "POST" && url.pathname === "/unlock") {
+      const info = await request.json() as LockInfo;
+      const result = await this.unlock(info);
+      return new Response(null, { 
+        status: result ? 200 : 423 
+      });
+    }
+    
+    return new Response("Not found", { status: 404 });
+  }
+
   async lock(info: LockInfo): Promise<boolean> {
     const currentLock: LockInfo =
       ((await this.ctx.storage.get("lock")) as LockInfo) || null;

--- a/src/endpoints/stateDelete.ts
+++ b/src/endpoints/stateDelete.ts
@@ -46,14 +46,21 @@ export class StateDelete extends OpenAPIRoute {
     const key = `${projectName}.tfstate`;
     const id = env.TF_STATE_LOCK.idFromName(key);
     const stub = env.TF_STATE_LOCK.get(id);
-    const lockInfo = await stub.getLockInfo();
+    
+    // Get lock info using fetch
+    const lockResponse = await stub.fetch("http://internal/lock");
+    const lockInfo = await lockResponse.json();
 
     if (lockInfo) {
       console.log(`State is currently locked by ${lockInfo.ID}`);
       return new Response(null, { status: 423 });
     }
-
-    await stub.unlock();
+    
+    // Unlock using fetch (sending an empty object since we're just deleting anyway)
+    await stub.fetch("http://internal/unlock", {
+      method: "POST",
+      body: JSON.stringify({})
+    });
 
     console.log("Unlocked state for", projectName);
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -245,6 +245,19 @@ describe("Estado Worker", () => {
 
       expect(response.status).toBe(405);
     });
+    
+    it("should return 404 for unknown Durable Object endpoints", async () => {
+      // Create a custom request to access an unknown path in the Durable Object
+      // First get the stub ID
+      const key = `myproject.tfstate`;
+      const id = env.TF_STATE_LOCK.idFromName(key);
+      const stub = env.TF_STATE_LOCK.get(id);
+      
+      // Send a request to an unknown path
+      const response = await stub.fetch("http://internal/unknown-path");
+      
+      expect(response.status).toBe(404);
+    });
 
     afterAll(async () => {
       const request = new IncomingRequest("http://example.com/myproject/lock", {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,7 +16,7 @@ class_name = "DurableState"
 # Durable Object migrations.
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/#migrations
 [[migrations]]
-tag = "v1"
+tag = "v1.0.1"
 new_classes = ["DurableState"]
 
 # Bind an R2 Bucket. Use R2 to store arbitrarily large blobs of data, such as files.


### PR DESCRIPTION
- Added fetch method to DurableState class to handle incoming requests
- Updated stateLock.ts and stateDelete.ts to use stub.fetch() instead of directly calling methods
- Implemented proper HTTP methods for Durable Object communication